### PR TITLE
Use venv for scripts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,6 @@
     "forwardPorts": [
         5000
     ],
-    "postCreateCommand": "python3 -m pip install -r requirements-dev.txt",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "8gb"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This repo contains sample code for a simple chat webapp that integrates with Azu
 - To use Azure OpenAI on your data: an existing Azure Cognitive Search resource and index.
 
 ## Deploy the app
-### Deploy with Azure Developer tools
-Please see README_azd.md for detailed instructions.
+
+### Deploy with Azure Developer CLI
+Please see [README_azd.md](./README_azd.md) for detailed instructions.
 
 ### One click Azure deployment
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fsample-app-aoai-chatGPT%2Fmain%2Finfrastructure%2Fdeployment.json)

--- a/README_azd.md
+++ b/README_azd.md
@@ -22,16 +22,8 @@ If you're not using one of those options for opening the project, then you'll ne
     - [Powershell 7+ (pwsh)](https://github.com/powershell/powershell) - For Windows users only.
     - **Important**: Ensure you can run `pwsh.exe` from a PowerShell command. If this fails, you likely need to upgrade PowerShell.
 
-2. Create a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments) and activate it.
 
-3. Install the Python requirements:
-
-    ```shell
-    python3 -m pip install -r requirements-dev.txt
-    ```
-
-
-### Starting from scratch:
+### Deploying from scratch:
 
 If you don't have any pre-existing Azure services (i.e. OpenAI or Cognitive Search service), then you can provision
 all resources from scratch by following these steps:
@@ -41,7 +33,7 @@ all resources from scratch by following these steps:
 1. After the application has been successfully deployed you will see a URL printed to the console.  Click that URL to interact with the application in your browser.
     > NOTE: It may take a minute for the application to be fully deployed. If you see a "Python Developer" welcome screen, then wait a minute and refresh the page.
 
-### Use existing resources:
+### Using existing resources:
 
 If you have existing Azure resources that you want to reuse, then you must first set `azd` environment variables _before_ running `azd up`.
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -35,11 +35,11 @@ hooks:
     postprovision:
       windows:
         shell: pwsh
-        run: ./scripts/auth_update.ps1;./scripts/prepdocs.ps1; $output = azd env get-values; Add-Content -Path .env -Value $output;
+        run: ./scripts/auth_update.ps1;./scripts/prepdocs.ps1;
         interactive: true
         continueOnError: false
       posix:
         shell: sh
-        run: ./scripts/auth_update.sh;./scripts/prepdocs.sh;azd env get-values > .env
+        run: ./scripts/auth_update.sh;./scripts/prepdocs.sh;
         interactive: true
         continueOnError: false

--- a/scripts/auth_init.ps1
+++ b/scripts/auth_init.ps1
@@ -1,10 +1,10 @@
-. ./loadenv.ps1
+. ./scripts/loadenv.ps1
 
-$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
-if (-not $pythonCmd) {
-  # fallback to python3 if python not found
-  $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+$venvPythonPath = "./.venv/scripts/python.exe"
+if (Test-Path -Path "/usr") {
+  # fallback to Linux venv path
+  $venvPythonPath = "./.venv/bin/python"
 }
 
 Write-Host 'Running "auth_init.py"'
-Start-Process -FilePath ($pythonCmd).Source -ArgumentList "./scripts/auth_init.py --appid $env:AUTH_APP_ID" -Wait -NoNewWindow
+Start-Process -FilePath $venvPythonPath -ArgumentList "./scripts/auth_init.py --appid $env:AUTH_APP_ID" -Wait -NoNewWindow

--- a/scripts/auth_init.ps1
+++ b/scripts/auth_init.ps1
@@ -7,4 +7,5 @@ if (Test-Path -Path "/usr") {
 }
 
 Write-Host 'Running "auth_init.py"'
-Start-Process -FilePath $venvPythonPath -ArgumentList "./scripts/auth_init.py --appid $env:AUTH_APP_ID" -Wait -NoNewWindow
+$appId = $env:AUTH_APP_ID ?? "no-id"
+Start-Process -FilePath $venvPythonPath -ArgumentList "./scripts/auth_init.py --appid $appId" -Wait -NoNewWindow

--- a/scripts/auth_init.py
+++ b/scripts/auth_init.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
 
     credential = AzureDeveloperCliCredential()
 
-    if args.appid:
+    if args.appid and args.appid != "no-id":
         print(f"Checking if application {args.appid} exists")
         if check_for_application(credential, args.appid):
             print("Application already exists, not creating new one.")

--- a/scripts/auth_init.sh
+++ b/scripts/auth_init.sh
@@ -3,4 +3,4 @@
 . ./scripts/loadenv.sh
 
 echo 'Running "auth_init.py"'
-python3 ./scripts/auth_init.py --appid "$AUTH_APP_ID"
+./.venv/bin/python ./scripts/auth_init.py --appid "$AUTH_APP_ID"

--- a/scripts/auth_update.ps1
+++ b/scripts/auth_update.ps1
@@ -1,10 +1,10 @@
-. ./loadenv.ps1
+. ./scripts/loadenv.ps1
 
-$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
-if (-not $pythonCmd) {
-  # fallback to python3 if python not found
-  $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+$venvPythonPath = "./.venv/scripts/python.exe"
+if (Test-Path -Path "/usr") {
+  # fallback to Linux venv path
+  $venvPythonPath = "./.venv/bin/python"
 }
 
 Write-Host 'Running "auth_update.py"'
-Start-Process -FilePath ($pythonCmd).Source -ArgumentList "./scripts/auth_update.py --appid $env:AUTH_APP_ID --uri $env:BACKEND_URI" -Wait -NoNewWindow
+Start-Process -FilePath $venvPythonPath -ArgumentList "./scripts/auth_update.py --appid $env:AUTH_APP_ID --uri $env:BACKEND_URI" -Wait -NoNewWindow

--- a/scripts/auth_update.sh
+++ b/scripts/auth_update.sh
@@ -3,4 +3,4 @@
 . ./scripts/loadenv.sh
 
 echo 'Running "auth_update.py"'
-python3 ./scripts/auth_update.py --appid "$AUTH_APP_ID" --uri "$BACKEND_URI"
+./.venv/bin/python ./scripts/auth_update.py --appid "$AUTH_APP_ID" --uri "$BACKEND_URI"

--- a/scripts/loadenv.ps1
+++ b/scripts/loadenv.ps1
@@ -11,3 +11,21 @@ foreach ($line in $output) {
   $value = $value -replace '^\"|\"$'
   [Environment]::SetEnvironmentVariable($name, $value)
 }
+
+$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+if (-not $pythonCmd) {
+  # fallback to python3 if python not found
+  $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+}
+
+Write-Host 'Creating Python virtual environment ".venv" in root'
+Start-Process -FilePath ($pythonCmd).Source -ArgumentList "-m venv ./venv" -Wait -NoNewWindow
+
+$venvPythonPath = "./.venv/scripts/python.exe"
+if (Test-Path -Path "/usr") {
+  # fallback to Linux venv path
+  $venvPythonPath = "./.venv/bin/python"
+}
+
+Write-Host 'Installing dependencies from "requirements.txt" into virtual environment'
+Start-Process -FilePath $venvPythonPath -ArgumentList "-m pip install -r ./requirements-dev.txt" -Wait -NoNewWindow

--- a/scripts/loadenv.sh
+++ b/scripts/loadenv.sh
@@ -6,3 +6,9 @@ while IFS='=' read -r key value; do
 done <<EOF
 $(azd env get-values)
 EOF
+
+echo 'Creating Python virtual environment ".venv" in root'
+python -m venv .venv
+
+echo 'Installing dependencies from "requirements.txt" into virtual environment'
+.venv/bin/python -m pip install -r requirements-dev.txt

--- a/scripts/loadenv.sh
+++ b/scripts/loadenv.sh
@@ -8,7 +8,7 @@ $(azd env get-values)
 EOF
 
 echo 'Creating Python virtual environment ".venv" in root'
-python -m venv .venv
+python3 -m venv .venv
 
 echo 'Installing dependencies from "requirements.txt" into virtual environment'
-.venv/bin/python -m pip install -r requirements-dev.txt
+./.venv/bin/python -m pip install -r requirements-dev.txt

--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -1,11 +1,11 @@
-. ./loadenv.ps1
+. ./scripts/loadenv.ps1
 
-$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
-if (-not $pythonCmd) {
-  # fallback to python3 if python not found
-  $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+$venvPythonPath = "./.venv/scripts/python.exe"
+if (Test-Path -Path "/usr") {
+  # fallback to Linux venv path
+  $venvPythonPath = "./.venv/bin/python"
 }
 
 Write-Host 'Running "prepdocs.py"'
 $cwd = (Get-Location)
-Start-Process -FilePath ($pythonCmd).Source -ArgumentList "./scripts/prepdocs.py --searchservice $env:AZURE_SEARCH_SERVICE --index $env:AZURE_SEARCH_INDEX --formrecognizerservice $env:AZURE_FORMRECOGNIZER_SERVICE --tenantid $env:AZURE_TENANT_ID" -Wait -NoNewWindow
+Start-Process -FilePath $venvPythonPath -ArgumentList "./scripts/prepdocs.py --searchservice $env:AZURE_SEARCH_SERVICE --index $env:AZURE_SEARCH_INDEX --formrecognizerservice $env:AZURE_FORMRECOGNIZER_SERVICE --tenantid $env:AZURE_TENANT_ID" -Wait -NoNewWindow

--- a/scripts/prepdocs.sh
+++ b/scripts/prepdocs.sh
@@ -3,4 +3,4 @@
 . ./scripts/loadenv.sh
 
 echo 'Running "prepdocs.py"'
-python3 ./scripts/prepdocs.py --searchservice "$AZURE_SEARCH_SERVICE" --index "$AZURE_SEARCH_INDEX" --formrecognizerservice "$AZURE_FORMRECOGNIZER_SERVICE" --tenantid "$AZURE_TENANT_ID"
+./.venv/bin/python ./scripts/prepdocs.py --searchservice "$AZURE_SEARCH_SERVICE" --index "$AZURE_SEARCH_INDEX" --formrecognizerservice "$AZURE_FORMRECOGNIZER_SERVICE" --tenantid "$AZURE_TENANT_ID"

--- a/start.sh
+++ b/start.sh
@@ -19,11 +19,13 @@ if [ $? -ne 0 ]; then
     exit $?
 fi
 
+cd ..
+. ./scripts/loadenv.sh
+
 echo ""
 echo "Starting backend"
 echo ""
-cd ..
-python3 -m flask run --port=5000 --host=127.0.0.1 --reload --debug
+./.venv/bin/python  -m flask run --port=5000 --host=127.0.0.1 --reload --debug
 if [ $? -ne 0 ]; then
     echo "Failed to start backend"
     exit $?


### PR DESCRIPTION
Previously, my README included instructions for users to set up a virtual environment or use a dev container. However, it's easy to miss that instruction, and then the scripts unexpectedly install packages into the main Python requirement.

This PR changes the scripts to create a venv in the root and use that venv's Python for all the commands. This is similar to what's done in https://github.com/pamelafox/azure-search-openai-demo/ except that repo creates multiple venvs, one for backend and one for scripts. Given the overlap between them, I think it's more straightforward to create