### PR TITLE
Put checks in loadenv in case azd isnt around

### DIFF
--- a/scripts/loadenv.ps1
+++ b/scripts/loadenv.ps1
@@ -1,15 +1,23 @@
-Write-Host "Loading azd .env file from current environment"
+# Only load env from azd if azd command and azd environment exist
+if (-not (Get-Command azd -ErrorAction SilentlyContinue)) {
+  Write-Host "azd command not found, skipping .env file load"
+} else {
+  $output = azd env list
+  if (!($output -like "*true*")) {
+    Write-Output "No azd environments found, skipping .env file load"
+  } else {
+    Write-Host "Loading azd .env file from current environment"
+    $output = azd env get-values
+    foreach ($line in $output) {
+      if (!$line.Contains('=')) {
+        continue
+      }
 
-$output = azd env get-values
-
-foreach ($line in $output) {
-  if (!$line.Contains('=')) {
-    continue
+      $name, $value = $line.Split("=")
+      $value = $value -replace '^\"|\"$'
+      [Environment]::SetEnvironmentVariable($name, $value)
+    }
   }
-
-  $name, $value = $line.Split("=")
-  $value = $value -replace '^\"|\"$'
-  [Environment]::SetEnvironmentVariable($name, $value)
 }
 
 $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
@@ -19,7 +27,7 @@ if (-not $pythonCmd) {
 }
 
 Write-Host 'Creating Python virtual environment ".venv" in root'
-Start-Process -FilePath ($pythonCmd).Source -ArgumentList "-m venv ./venv" -Wait -NoNewWindow
+Start-Process -FilePath ($pythonCmd).Source -ArgumentList "-m venv ./.venv" -Wait -NoNewWindow
 
 $venvPythonPath = "./.venv/scripts/python.exe"
 if (Test-Path -Path "/usr") {

--- a/scripts/loadenv.sh
+++ b/scripts/loadenv.sh
@@ -1,11 +1,20 @@
-echo "Loading azd .env file from current environment"
-
-while IFS='=' read -r key value; do
-    value=$(echo "$value" | sed 's/^"//' | sed 's/"$//')
-    export "$key=$value"
-done <<EOF
-$(azd env get-values)
+# Only load env from azd if azd command and azd environment exist
+if not command -v azd &> /dev/null; then
+    echo "azd command not found, skipping .env file load"
+else
+    if [ -z "$(azd env list | grep -w true | awk '{print $1}')" ]; then
+        echo "No azd environments found, skipping .env file load"
+    else
+        echo "Loading azd .env file from current environment"
+        while IFS='=' read -r key value; do
+        value=$(echo "$value" | sed 's/^"//' | sed 's/"$//')
+        export "$key=$value"
+        done <<EOF
+$(azd env get-values --no-prompt)
 EOF
+    fi
+fi
+
 
 echo 'Creating Python virtual environment ".venv" in root'
 python3 -m venv .venv


### PR DESCRIPTION
Fixes #59 

This PR adds conditionals to loadenv.sh and loadenv.ps1 to check that the azd command exists and that there's a current azd env. I tested by loading in a dev container with/without azd, and by deleting the .azure folder to simulate no environment.
