### PR TITLE
Ignore Enter during IME conversion.

### DIFF
--- a/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -27,7 +27,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend }: Pr
     };
 
     const onEnterPress = (ev: React.KeyboardEvent<Element>) => {
-        if (ev.key === "Enter" && !ev.shiftKey) {
+        if (ev.key === "Enter" && !ev.shiftKey && !(ev.nativeEvent?.isComposing === true)) {
             ev.preventDefault();
             sendQuestion();
         }


### PR DESCRIPTION
## Summary

This pull request fixes a issue with the Input Method Editor (IME) being sent on Enter during conversion. This problem happens when typing Japanese, Chinese, Korean, and other languages that use IMEs.

## Changes

To fix this issue, we use the `isComposing` property of nativeEvent. The `isComposing` property is true while typing in IME, so we can ignore Enter during IME conversion.