### PR TITLE
Bicep Update Aug 2023

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -25,7 +25,7 @@ param searchIndexName string = 'gptkbindex'
 param searchUseSemanticSearch bool = false
 param searchSemanticSearchConfig string = 'default'
 param searchTopK int = 5
-param searchEnableInDomain bool = false
+param searchEnableInDomain bool = true
 param searchContentColumns string = 'content'
 param searchFilenameColumn string = 'filepath'
 param searchTitleColumn string = 'title'
@@ -88,7 +88,7 @@ module appServicePlan 'core/host/appserviceplan.bicep' = {
     location: location
     tags: tags
     sku: {
-      name: 'P1V2' // Upgrade to Premium v2 plan (for production purpose) from 'B1'
+      name: 'B1'
       capacity: 1
     }
     kind: 'linux'

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -5,9 +5,6 @@
     "environmentName": {
       "value": "${AZURE_ENV_NAME}"
     },
-    "resourceGroupName": {
-      "value": "${AZURE_RG_NAME}"
-    },
     "location": {
       "value": "${AZURE_LOCATION}"
     },

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -5,6 +5,9 @@
     "environmentName": {
       "value": "${AZURE_ENV_NAME}"
     },
+    "resourceGroupName": {
+      "value": "${AZURE_RG_NAME}"
+    },
     "location": {
       "value": "${AZURE_LOCATION}"
     },
@@ -20,6 +23,23 @@
     "openAiSkuName": {
       "value": "${AZURE_OPENAI_SKU_NAME}"
     },
+
+    "openAIModelDeployment": {
+      "value": "${AZURE_OPENAI_MODEL_NAME}"
+    },
+
+    "openAIModelVersion": {
+      "value": "${AZURE_OPENAI_MODEL_VERSION}"
+    },
+
+    "openAIModelLabel": {
+      "value": "${AZURE_OPENAI_MODEL_LABEL}"
+    },
+
+    "openAIModelCapacity": {
+      "value": "${AZURE_OPENAI_MODEL_CAPACITY}"
+    },
+
     "searchServiceName": {
       "value": "${AZURE_SEARCH_SERVICE}"
     },


### PR DESCRIPTION
- Added additional parameters to deploy different model version with `azd`, e.g., to deploy a gpt-4 model, set this additional parameters
  * `azd env set AZURE_OPENAI_MODEL_NAME gpt-4`
  * `azd env set AZURE_OPENAI_MODEL_VERSION 0613`

- Additional, but optional parameters have been added
  * control the name of the model within AOAI: `AZURE_OPENAI_MODEL_LABEL`, defaults to `turbo`
  * Ability to change the Capacity through `AZURE_OPENAI_MODEL_CAPACITY`, defaults to `30`

- In addition, if you keep AZURE_SEARCH_SERVICE empty, no search service will get created (so pure use of the LLM)