### PR TITLE
Add option to hide auth deployment time info

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -52,6 +52,8 @@ const Chat = () => {
     const [clearingChat, setClearingChat] = useState<boolean>(false);
     const [hideErrorDialog, { toggle: toggleErrorDialog }] = useBoolean(true);
     const [errorMsg, setErrorMsg] = useState<ErrorMessage | null>()
+    const searchParams = new URLSearchParams(document.location.search);
+    const manualAuth  = searchParams.get('manualAuth') === 'true';
 
     const errorDialogContentProps = {
         type: DialogType.close,
@@ -531,8 +533,12 @@ const Chat = () => {
                         and following 
                          <a href="https://learn.microsoft.com/en-us/azure/app-service/scenario-secure-app-authentication-app-service#3-configure-authentication-and-authorization" target="_blank"> these instructions</a>.
                     </h2>
-                    <h2 className={styles.chatEmptyStateSubtitle} style={{fontSize: "20px"}}><strong>Authentication configuration takes a few minutes to apply. </strong></h2>
-                    <h2 className={styles.chatEmptyStateSubtitle} style={{fontSize: "20px"}}><strong>If you deployed in the last 10 minutes, please wait and reload the page after 10 minutes.</strong></h2>
+                    {!manualAuth && (
+                        <>
+                            <h2 className={styles.chatEmptyStateSubtitle} style={{fontSize: "20px"}}><strong>Authentication configuration takes a few minutes to apply. </strong></h2>
+                            <h2 className={styles.chatEmptyStateSubtitle} style={{fontSize: "20px"}}><strong>If you deployed in the last 10 minutes, please wait and reload the page after 10 minutes.</strong></h2>
+                        </>
+                    )}
                 </Stack>
             ) : (
                 <Stack horizontal className={styles.chatRoot}>


### PR DESCRIPTION
This PR enables hiding the messaging around configuration time to avoid confusion in cases where authentication must be manually added by the user. 

To test, add `?manualAuth=true` on an instance that doesn't have auth configured yet. Without the query param, the behaviour is unchanged.