### PR TITLE
Fix clear chat button's behavior

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -641,7 +641,7 @@ const Chat = () => {
                                     }}
                                     className={appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured ? styles.clearChatBroom : styles.clearChatBroomNoCosmos}
                                     iconProps={{ iconName: 'Broom' }}
-                                    onClick={clearChat}
+                                    onClick={appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured ? clearChat : newChat}
                                     disabled={disabledButton()}
                                     aria-label="clear chat button"
                                 />


### PR DESCRIPTION
This PR fixes the behavior of the clear chat button.

Issue:
There is no response when clicking the clear chat button while using the Web App without setting up Cosmos DB.

Correction:
When the clear chat button is clicked without setting up Cosmos DB, it will clear the chat content and start a new chat.