### PR TITLE
Feat: Add apim-request-id to stream_with_data response

### DIFF
--- a/app.py
+++ b/app.py
@@ -214,10 +214,12 @@ def stream_with_data(body, headers, endpoint, history_metadata={}):
         "choices": [{
             "messages": []
         }],
+        "apim-request-id": "",
         'history_metadata': history_metadata
     }
     try:
         with s.post(endpoint, json=body, headers=headers, stream=True) as r:
+            apimRequestId = r.headers._store.get('apim-request-id')[1]
             for line in r.iter_lines(chunk_size=10):
                 if line:
                     lineJson = json.loads(line.lstrip(b'data:').decode('utf-8'))
@@ -227,6 +229,7 @@ def stream_with_data(body, headers, endpoint, history_metadata={}):
                     response["model"] = lineJson["model"]
                     response["created"] = lineJson["created"]
                     response["object"] = lineJson["object"]
+                    response["apim-request-id"] = apimRequestId
 
                     role = lineJson["choices"][0]["messages"][0]["delta"].get("role")
                     if role == "tool":

--- a/app.py
+++ b/app.py
@@ -219,7 +219,7 @@ def stream_with_data(body, headers, endpoint, history_metadata={}):
     }
     try:
         with s.post(endpoint, json=body, headers=headers, stream=True) as r:
-            apimRequestId = r.headers._store.get('apim-request-id')[1]
+            apimRequestId = r.headers.get('apim-request-id')
             for line in r.iter_lines(chunk_size=10):
                 if line:
                     lineJson = json.loads(line.lstrip(b'data:').decode('utf-8'))


### PR DESCRIPTION
This PR adds an `apim-request-id` key:value to the `stream_with_data` function making it available in the `result` object.

![Screenshot 2023-10-16 132126](https://github.com/microsoft/sample-app-aoai-chatGPT/assets/994856/cdcbeab8-3354-444b-9e3f-02860e5798b0)
