### PR TITLE
Fix empty messages (#366)

### DIFF
--- a/app.py
+++ b/app.py
@@ -400,10 +400,11 @@ def conversation_without_data(request_body):
     ]
 
     for message in request_messages:
-        messages.append({
-            "role": message["role"] ,
-            "content": message["content"]
-        })
+        if message and "role" in message and "content" in message:
+            messages.append({
+                "role": message["role"] ,
+                "content": message["content"]
+            })
 
     response = openai.ChatCompletion.create(
         engine=AZURE_OPENAI_MODEL,


### PR DESCRIPTION
🔀 Ignore empty message

Quick fix. Empty messages are now ignored instead of causing a crash.

Issue: #366 