### PR TITLE
[bug] Running chat without data fails on second message due to nonexistent tool message

### DIFF
--- a/app.py
+++ b/app.py
@@ -400,10 +400,11 @@ def conversation_without_data(request_body):
     ]
 
     for message in request_messages:
-        messages.append({
-            "role": message["role"] ,
-            "content": message["content"]
-        })
+        if message:
+            messages.append({
+                "role": message["role"] ,
+                "content": message["content"]
+            })
 
     response = openai.ChatCompletion.create(
         engine=AZURE_OPENAI_MODEL,


### PR DESCRIPTION
This PR addresses a bug discovered [here](https://github.com/microsoft/sample-app-aoai-chatGPT/issues/366) due a nonexistent tool message when running the chat app without data. 

This bug was introduced because of a workflow issue with VScode that is now addressed.