### PR TITLE
(fix) Empty messages prevents getting an answer to the second question

### DIFF
--- a/app.py
+++ b/app.py
@@ -400,11 +400,15 @@ def conversation_without_data(request_body):
     ]
 
     for message in request_messages:
-        messages.append({
-            "role": message["role"] ,
-            "content": message["content"]
-        })
+        print(message)
+        if message.get("role") is not None:
+            messages.append({
+                "role": message["role"] ,
+                "content": message["content"]
+            })
 
+
+    print(f'Calling endpoint {openai.api_base} with api-version={openai.api_version}...')
     response = openai.ChatCompletion.create(
         engine=AZURE_OPENAI_MODEL,
         messages = messages,


### PR DESCRIPTION
Empty messages prevent getting an answer to the second question in the chat.
Adding log to which endpoint the message is being sent to