### PR TITLE
Fix: Check for empty tool message in history/update

### DIFF
--- a/app.py
+++ b/app.py
@@ -521,7 +521,7 @@ def update_conversation():
         ## then write it to the conversation history in cosmos
         messages = request.json["messages"]
         if len(messages) > 0 and messages[-1]['role'] == "assistant":
-            if len(messages) > 1 and messages[-2]['role'] == "tool":
+            if len(messages) > 1 and messages[-2] != {} and messages[-2]['role'] == "tool":
                 # write the tool message first
                 cosmos_conversation_client.create_message(
                     conversation_id=conversation_id,


### PR DESCRIPTION
This PR addresses the empty tool message in the history/update route. The frontend is currently sending an empty object for the tool message. A more robust solution addressing the frontend to come later.