### PR TITLE
Add tags to deployment template

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repo contains sample code for a simple chat webapp that integrates with Azu
 - To use Azure OpenAI on your data: an existing Azure Cognitive Search resource and index.
 
 ## Deploy the app
+### Note: Deployment from Azure OpenAI Chat Playground
+Your manually-deployed apps can be updated from the Azure OpenAI Chat Playground as well. The update will change all of the app settings to match the current chat playground state, without overwriting the code currently running in the app. To enable updates from the playground, ensure that your app has a resource tag named **ProjectType** with value **aoai-your-data-service**.
 
 ### Deploy with Azure Developer CLI
 Please see [README_azd.md](./README_azd.md) for detailed instructions.

--- a/infrastructure/deployment.json
+++ b/infrastructure/deployment.json
@@ -293,6 +293,9 @@
             "identity": {
                 "type": "SystemAssigned"
             },
+            "tags": {
+                "ProjectType": "aoai-your-data-service"
+            },
             "properties": {
                 "serverFarmId": "[parameters('HostingPlanName')]",
                 "siteConfig": {


### PR DESCRIPTION
Resource tag allows apps to be listed in the chat playground when deploying to an existing app.