### PR TITLE
Remove unused AAD token to support other identity providers

### DIFF
--- a/backend/auth/auth_utils.py
+++ b/backend/auth/auth_utils.py
@@ -10,9 +10,11 @@ def get_authenticated_user_details(request_headers):
         ## if it is, get the user details from the EasyAuth headers
         raw_user_object = {k:v for k,v in request_headers.items()}
 
-    user_object['user_principal_id'] = raw_user_object['X-Ms-Client-Principal-Id']
-    user_object['user_name'] = raw_user_object['X-Ms-Client-Principal-Name']
-    user_object['auth_provider'] = raw_user_object['X-Ms-Client-Principal-Idp']
-    user_object['client_principal_b64'] = raw_user_object['X-Ms-Client-Principal']
+    user_object['user_principal_id'] = raw_user_object.get('X-Ms-Client-Principal-Id')
+    user_object['user_name'] = raw_user_object.get('X-Ms-Client-Principal-Name')
+    user_object['auth_provider'] = raw_user_object.get('X-Ms-Client-Principal-Idp')
+    user_object['auth_token'] = raw_user_object.get('X-Ms-Token-Aad-Id-Token')
+    user_object['client_principal_b64'] = raw_user_object.get('X-Ms-Client-Principal')
+    user_object['aad_id_token'] = raw_user_object.get('X-Ms-Token-Aad-Id-Token')
 
     return user_object

--- a/backend/auth/auth_utils.py
+++ b/backend/auth/auth_utils.py
@@ -13,8 +13,6 @@ def get_authenticated_user_details(request_headers):
     user_object['user_principal_id'] = raw_user_object['X-Ms-Client-Principal-Id']
     user_object['user_name'] = raw_user_object['X-Ms-Client-Principal-Name']
     user_object['auth_provider'] = raw_user_object['X-Ms-Client-Principal-Idp']
-    user_object['auth_token'] = raw_user_object['X-Ms-Token-Aad-Id-Token']
     user_object['client_principal_b64'] = raw_user_object['X-Ms-Client-Principal']
-    user_object['aad_id_token'] = raw_user_object["X-Ms-Token-Aad-Id-Token"]
 
     return user_object


### PR DESCRIPTION
Fixes #457

Requiring the key `X-Ms-Token-Aad-Id-Token` effectively requires using AAD/Microsoft as identity provider and produces and error and the loss of chat history with other identity providers.

Removing the dependency in `auth_utils.py` as the **AAD token is not used anywhere in the app**. 

This fixes the dependency on AAD and allows other identity providers, such as OpenID, to be used.

Ready for review.