### PR TITLE
Set `EMBEDDING_MODEL_KEY` at cosmos_mongo_vcore_data_preparation.py

### DIFF
--- a/scripts/cosmos_mongo_vcore_data_preparation.py
+++ b/scripts/cosmos_mongo_vcore_data_preparation.py
@@ -251,7 +251,7 @@ if __name__ == "__main__":
         if index_config.get("index_name") and not args.embedding_model_endpoint:
             raise Exception("ERROR: Vector search is enabled in the config, but no embedding model endpoint and key were provided. Please provide these values or disable vector search.")
         print("Preparing data for index:", index_config["index_name"])
-
+        os.environ["EMBEDDING_MODEL_KEY"] = args.embedding_model_key
         create_index(index_config, credential, form_recognizer_client, embedding_model_endpoint=args.embedding_model_endpoint, use_layout=args.form_rec_use_layout, njobs=args.njobs)
         print("Data preparation for index", index_config["index_name"], "completed")
 


### PR DESCRIPTION
if we don't set this environment variable, we can't get embedding vector by `get_embedding()` func at `data_utils.py`, and we face the `No chunks found. Please check the data path and chunk size.` error. so, we need to set `EMBEDDING_MODEL_KEY` at `cosmos_mongo_vcore_data_preparation.py`.

//repro step
1. cd scripts
2. python ./cosmos_mongo_vcore_data_preparation.py --cosmos-config ./cosmos_config.json --njobs=4 --embedding-model-endpoint https://<your-aoai-resource>.openai.azure.com/openai/deployments/<your-embedding-deploymentId>/embeddings?api-version=2023-03-15-preview --embedding-model-key "your-api-key"
3. we face the `No chunks found. Please check the data path and chunk size.` error