### PR TITLE
prevent submitting while composing

### DIFF
--- a/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -14,6 +14,7 @@ interface Props {
 
 export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conversationId }: Props) => {
     const [question, setQuestion] = useState<string>("");
+    const [isComposing, setIsComposing] = useState<boolean>(false)
 
     const sendQuestion = () => {
         if (disabled || !question.trim()) {
@@ -32,7 +33,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
     };
 
     const onEnterPress = (ev: React.KeyboardEvent<Element>) => {
-        if (ev.key === "Enter" && !ev.shiftKey) {
+        if (ev.key === "Enter" && !ev.shiftKey && !isComposing) {
             ev.preventDefault();
             sendQuestion();
         }
@@ -43,6 +44,9 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
     };
 
     const sendQuestionDisabled = disabled || !question.trim();
+
+    const onCompositionStart = () => setIsComposing(true)
+    const onCompositionEnd = () => setIsComposing(false)
 
     return (
         <Stack horizontal className={styles.questionInputContainer}>
@@ -55,6 +59,8 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, conv
                 value={question}
                 onChange={onQuestionChange}
                 onKeyDown={onEnterPress}
+                onCompositionStart={onCompositionStart}
+                onCompositionEnd={onCompositionEnd}
             />
             <div className={styles.questionInputSendButtonContainer} 
                 role="button" 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

In QuestionInput, it submit when you press enter key. But when writing Japanese texts, people use the enter key to commit the candidate characters. It is quite hard to use kanji in the input.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

I've added a state to check [composition events](https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent) of the input to prevent submitting while composing the text.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
