### PR TITLE
[Refactor] Remove global message_id from feedback implementation

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -71,7 +71,7 @@ def generateFilterString(userToken):
 
 def format_non_streaming_response(chatCompletion, history_metadata, message_uuid=None):
     response_obj = {
-        "id": message_uuid if message_uuid else chatCompletion.id,
+        "id": chatCompletion.id,
         "model": chatCompletion.model,
         "created": chatCompletion.created,
         "object": chatCompletion.object,
@@ -108,7 +108,7 @@ def format_non_streaming_response(chatCompletion, history_metadata, message_uuid
 
 def format_stream_response(chatCompletionChunk, history_metadata, message_uuid=None):
     response_obj = {
-        "id": message_uuid if message_uuid else chatCompletionChunk.id,
+        "id": chatCompletionChunk.id,
         "model": chatCompletionChunk.model,
         "created": chatCompletionChunk.created,
         "object": chatCompletionChunk.object,


### PR DESCRIPTION
### Motivation and Context

This solves two issues 1: Previously to achieve adding the feedback feature a `global message_id` was used this worked but a global variable wasn't desirable. 2: When the async work was merged in the use of the global variable made the feedback feature unusable at times. 

### Description

This reactor removes the use of the global variable and utilizes the correct assistant message id.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- Built and tested locally and in a deployed app
- backend only
- This is for all users
- No breaking changes
