### PR TITLE
Responsive updates to Answer footer

### DIFF
--- a/frontend/src/components/Answer/Answer.module.css
+++ b/frontend/src/components/Answer/Answer.module.css
@@ -173,3 +173,11 @@ sup {
     font-size: 10px;
     line-height: 10px;
 }
+
+@media (max-width: 480px) {
+    .answerFooter, .answerDisclaimerContainer{
+        flex-direction: column;
+        align-items: left; 
+        gap: 4px; 
+    }
+}


### PR DESCRIPTION
Updates to make Answer footer responsive. The Answer footer includes the references and Answer disclaimer.

### Motivation and Context

The Answer disclaimer does not fit when viewed on small screen devices. 
![image](https://github.com/microsoft/sample-app-aoai-chatGPT/assets/5420965/f167d288-deb5-4175-9338-1e7a658c3fe0)


<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? Answer disclaimer does not fit when viewed on mobile devices, for example, iphone 14, 15 etc.
  2. What problem does it solve? Responsive Answer footer on small screen devices such as mobile devices like iphone 14, 15 etc. 
  3. What scenario does it contribute to? Making app more responsive. The Answer footer needs to be made responsive to small screen devices. 
  4. If it fixes an open issue, please link to the issue here. [#647](https://github.com/microsoft/sample-app-aoai-chatGPT/issues/647)
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app. Yes. all users. 
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Added media query to Answer.module.css file to support small screen devices.

@media (max-width: 480px) {
    .answerFooter, .answerDisclaimerContainer{
        flex-direction: column;
        align-items: left; 
        gap: 4px; 
    }
}

**After:**

![image](https://github.com/microsoft/sample-app-aoai-chatGPT/assets/5420965/2b2a62ae-f37d-4d8d-ad56-24f075fb3407)


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
