### PR TITLE
Add stricter checking for user access token for document level access control

### DIFF
--- a/app.py
+++ b/app.py
@@ -309,6 +309,8 @@ def get_configured_data_source():
         if AZURE_SEARCH_PERMITTED_GROUPS_COLUMN:
             userToken = request.headers.get('X-MS-TOKEN-AAD-ACCESS-TOKEN', "")
             logging.debug(f"USER TOKEN is {'present' if userToken else 'not present'}")
+            if not userToken:
+                raise Exception("Document-level access control is enabled, but user access token could not be fetched.")
 
             filter = generateFilterString(userToken)
             logging.debug(f"FILTER: {filter}")
@@ -579,7 +581,7 @@ async def conversation_internal(request_body):
     
     except Exception as ex:
         logging.exception(ex)
-        if ex.status_code:
+        if hasattr(ex, "status_code"):
             return jsonify({"error": str(ex)}), ex.status_code
         else:
             return jsonify({"error": str(ex)}), 500


### PR DESCRIPTION
### Description

Ensure that when document level access control is enabled, user access token must be present, and raise an exception if not. The user access token can be missing if:
- authentication is not enabled on the app service
- a non-Microsoft identity provider is used for authentication
- the Microsoft identity provider for authentication is not configured with a client secret

In all of these cases, fail the request because we can't properly respect document-level access control.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
