### PR TITLE
Fix UI_SHOW_SHARE_BUTTON issue

### DIFF
--- a/frontend/src/components/common/Button.module.css
+++ b/frontend/src/components/common/Button.module.css
@@ -4,7 +4,6 @@
     border-radius: 4px;
     background: radial-gradient(109.81% 107.82% at 100.1% 90.19%, #0F6CBD 33.63%, #2D87C3 70.31%, #8DDDD8 100%);
     padding: 5px 12px;
-    margin-right: 20px;
   }
   
   .shareButtonRoot:hover {

--- a/frontend/src/pages/layout/Layout.module.css
+++ b/frontend/src/pages/layout/Layout.module.css
@@ -56,6 +56,10 @@
     cursor: pointer;
 }
 
+.layoutButtonStack {
+    margin-right: 20px;
+}
+
 .shareButton {
     color: #FFFFFF;
 }

--- a/frontend/src/pages/layout/Layout.tsx
+++ b/frontend/src/pages/layout/Layout.tsx
@@ -78,14 +78,14 @@ const Layout = () => {
                             <h1 className={styles.headerTitle}>{ui?.title}</h1>
                         </Link>
                     </Stack>
-                    {ui?.show_share_button &&
-                        <Stack horizontal tokens={{ childrenGap: 4 }}>
+                        <Stack horizontal tokens={{ childrenGap: 4 }} className={styles.layoutButtonStack}>
                             {(appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured) &&
                                 <HistoryButton onClick={handleHistoryClick} text={appStateContext?.state?.isChatHistoryOpen ? hideHistoryLabel : showHistoryLabel} />
                             }
-                            <ShareButton onClick={handleShareClick} text={shareLabel} />
+                        {ui?.show_share_button &&
+                           <ShareButton onClick={handleShareClick} text={shareLabel} />
+                        }
                         </Stack>
-                    }
                 </Stack>
             </header>
             <Outlet />


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
          There is a bug in the UI_SHOW_SHARE_BUTTON logic.
  2. What problem does it solve?
          Hiding the Share Button also hides the Chat History button. It should only hide the share button. Also, the right gutter padding is incorrectly applied to the share button such that, once hidden, the Chat history button slides over to the edge of the page.
  3. What scenario does it contribute to?
          Global UI Variables
  4. If it fixes an open issue, please link to the issue here.
          Did not see this one.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
          Yes, this is a global but (if you hide the share button and have history enabled).
-->

### Description

Minimal changes to fix the issue.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ x ] I have built and tested the code locally and in a deployed app
- [ x ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ x ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ x ] I didn't break any existing functionality :smile:
