### PR TITLE
[fix] Remove tool dictionary from messages list in the aoai request

### DIFF
--- a/app.py
+++ b/app.py
@@ -851,6 +851,7 @@ async def complete_chat_request(request_body):
 async def stream_chat_request(request_body):
     response = await send_chat_request(request_body)
     history_metadata = request_body.get("history_metadata", {})
+
     async def generate():
         async for completionChunk in response:
             yield format_stream_response(completionChunk, history_metadata)
@@ -865,7 +866,6 @@ async def conversation_internal(request_body):
             response = await make_response(format_as_ndjson(result))
             response.timeout = None
             response.mimetype = "application/json-lines"
-            
             return response
         else:
             result = await complete_chat_request(request_body)
@@ -927,7 +927,6 @@ async def add_conversation():
         ## Format the incoming message object in the "chat/completions" messages format
         ## then write it to the conversation history in cosmos
         messages = request_json["messages"]
-        
         if len(messages) > 0 and messages[-1]["role"] == "user":
             createdMessageValue = await cosmos_conversation_client.create_message(
                 uuid=str(uuid.uuid4()),

--- a/app.py
+++ b/app.py
@@ -820,11 +820,14 @@ async def promptflow_request(request):
 
 
 async def send_chat_request(request):
+    filtered_messages = [message for message in request['messages'] if message['role'] != 'tool']
+    request['messages'] = filtered_messages
     model_args = prepare_model_args(request)
 
     try:
         azure_openai_client = init_openai_client()
         response = await azure_openai_client.chat.completions.create(**model_args)
+        print("response", response)
 
     except Exception as e:
         logging.exception("Exception in send_chat_request")
@@ -849,6 +852,8 @@ async def complete_chat_request(request_body):
 async def stream_chat_request(request_body):
     response = await send_chat_request(request_body)
     history_metadata = request_body.get("history_metadata", {})
+    # request_id = response.response.headers.get("apim-request-id", None)
+    # print("request_id", request_id)
 
     async def generate():
         async for completionChunk in response:
@@ -864,9 +869,11 @@ async def conversation_internal(request_body):
             response = await make_response(format_as_ndjson(result))
             response.timeout = None
             response.mimetype = "application/json-lines"
+            # print("response", response)
             return response
         else:
             result = await complete_chat_request(request_body)
+            # print("result", result)
             return jsonify(result)
 
     except Exception as ex:
@@ -925,6 +932,7 @@ async def add_conversation():
         ## Format the incoming message object in the "chat/completions" messages format
         ## then write it to the conversation history in cosmos
         messages = request_json["messages"]
+        # print("messages", messages)
         if len(messages) > 0 and messages[-1]["role"] == "user":
             createdMessageValue = await cosmos_conversation_client.create_message(
                 uuid=str(uuid.uuid4()),


### PR DESCRIPTION
### Motivation and Context

There was a bug that when the assistant couldn't respond with a relevant message (i.e. prompting hello over and over again) the assistant message would not be in the response exposing the tools message.

### Description

This PR remove the tool message from the request resulting in appropriate responses from the assistant.


![スクリーンショット 2024-04-03 175013](https://github.com/microsoft/sample-app-aoai-chatGPT/assets/994856/1c5e5321-9a48-4e1e-892b-2410741eef44)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
