### PR TITLE
Fix 'Unclosed client session' error

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import logging
 import uuid
 from dotenv import load_dotenv
 import httpx
+import asyncio
 from quart import (
     Blueprint,
     Quart,
@@ -13,6 +14,7 @@ from quart import (
     request,
     send_from_directory,
     render_template,
+    current_app,
 )
 
 from openai import AsyncAzureOpenAI
@@ -49,11 +51,23 @@ UI_CHAT_DESCRIPTION = (
 UI_FAVICON = os.environ.get("UI_FAVICON") or "/favicon.ico"
 UI_SHOW_SHARE_BUTTON = os.environ.get("UI_SHOW_SHARE_BUTTON", "true").lower() == "true"
 
+cosmos_db_ready = asyncio.Event()
 
 def create_app():
     app = Quart(__name__)
     app.register_blueprint(bp)
     app.config["TEMPLATES_AUTO_RELOAD"] = True
+    
+    @app.before_serving
+    async def init():
+        try:
+            app.cosmos_conversation_client = await init_cosmosdb_client()
+            cosmos_db_ready.set()
+        except Exception as e:
+            logging.exception("Failed to initialize CosmosDB client")
+            app.cosmos_conversation_client = None
+            raise e
+    
     return app
 
 
@@ -308,7 +322,7 @@ SHOULD_USE_DATA = should_use_data()
 
 
 # Initialize Azure OpenAI Client
-def init_openai_client(use_data=SHOULD_USE_DATA):
+async def init_openai_client(use_data=SHOULD_USE_DATA):
     azure_openai_client = None
     try:
         # API version check
@@ -337,9 +351,11 @@ def init_openai_client(use_data=SHOULD_USE_DATA):
         ad_token_provider = None
         if not aoai_api_key:
             logging.debug("No AZURE_OPENAI_KEY found, using Azure AD auth")
-            ad_token_provider = get_bearer_token_provider(
-                DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
-            )
+            async with DefaultAzureCredential() as credential:
+                ad_token_provider = get_bearer_token_provider(
+                    credential,
+                    "https://cognitiveservices.azure.com/.default"
+                )
 
         # Deployment
         deployment = AZURE_OPENAI_MODEL
@@ -364,8 +380,7 @@ def init_openai_client(use_data=SHOULD_USE_DATA):
         raise e
 
 
-def init_cosmosdb_client():
-    cosmos_conversation_client = None
+async def init_cosmosdb_client():
     if CHAT_HISTORY_ENABLED:
         try:
             cosmos_endpoint = (
@@ -373,7 +388,8 @@ def init_cosmosdb_client():
             )
 
             if not AZURE_COSMOSDB_ACCOUNT_KEY:
-                credential = DefaultAzureCredential()
+                async with DefaultAzureCredential() as cred:
+                    credential = cred
             else:
                 credential = AZURE_COSMOSDB_ACCOUNT_KEY
 
@@ -833,7 +849,7 @@ async def send_chat_request(request):
     model_args = prepare_model_args(request)
 
     try:
-        azure_openai_client = init_openai_client()
+        azure_openai_client = await init_openai_client()
         raw_response = await azure_openai_client.chat.completions.with_raw_response.create(**model_args)
         response = raw_response.parse()
         apim_request_id = raw_response.headers.get("apim-request-id") 
@@ -909,6 +925,7 @@ def get_frontend_settings():
 ## Conversation History API ##
 @bp.route("/history/generate", methods=["POST"])
 async def add_conversation():
+    await cosmos_db_ready.wait()
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
 
@@ -918,15 +935,14 @@ async def add_conversation():
 
     try:
         # make sure cosmos is configured
-        cosmos_conversation_client = init_cosmosdb_client()
-        if not cosmos_conversation_client:
+        if not current_app.cosmos_conversation_client:
             raise Exception("CosmosDB is not configured or not working")
 
         # check for the conversation_id, if the conversation is not set, we will create a new one
         history_metadata = {}
         if not conversation_id:
             title = await generate_title(request_json["messages"])
-            conversation_dict = await cosmos_conversation_client.create_conversation(
+            conversation_dict = await current_app.cosmos_conversation_client.create_conversation(
                 user_id=user_id, title=title
             )
             conversation_id = conversation_dict["id"]
@@ -937,7 +953,7 @@ async def add_conversation():
         ## then write it to the conversation history in cosmos
         messages = request_json["messages"]
         if len(messages) > 0 and messages[-1]["role"] == "user":
-            createdMessageValue = await cosmos_conversation_client.create_message(
+            createdMessageValue = await current_app.cosmos_conversation_client.create_message(
                 uuid=str(uuid.uuid4()),
                 conversation_id=conversation_id,
                 user_id=user_id,
@@ -952,8 +968,6 @@ async def add_conversation():
         else:
             raise Exception("No user message found")
 
-        await cosmos_conversation_client.cosmosdb_client.close()
-
         # Submit request to Chat Completions for response
         request_body = await request.get_json()
         history_metadata["conversation_id"] = conversation_id
@@ -967,6 +981,7 @@ async def add_conversation():
 
 @bp.route("/history/update", methods=["POST"])
 async def update_conversation():
+    await cosmos_db_ready.wait()
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
 
@@ -976,8 +991,7 @@ async def update_conversation():
 
     try:
         # make sure cosmos is configured
-        cosmos_conversation_client = init_cosmosdb_client()
-        if not cosmos_conversation_client:
+        if not current_app.cosmos_conversation_client:
             raise Exception("CosmosDB is not configured or not working")
 
         # check for the conversation_id, if the conversation is not set, we will create a new one
@@ -990,14 +1004,14 @@ async def update_conversation():
         if len(messages) > 0 and messages[-1]["role"] == "assistant":
             if len(messages) > 1 and messages[-2].get("role", None) == "tool":
                 # write the tool message first
-                await cosmos_conversation_client.create_message(
+                await current_app.cosmos_conversation_client.create_message(
                     uuid=str(uuid.uuid4()),
                     conversation_id=conversation_id,
                     user_id=user_id,
                     input_message=messages[-2],
                 )
             # write the assistant message
-            await cosmos_conversation_client.create_message(
+            await current_app.cosmos_conversation_client.create_message(
                 uuid=messages[-1]["id"],
                 conversation_id=conversation_id,
                 user_id=user_id,
@@ -1007,7 +1021,6 @@ async def update_conversation():
             raise Exception("No bot messages found")
 
         # Submit request to Chat Completions for response
-        await cosmos_conversation_client.cosmosdb_client.close()
         response = {"success": True}
         return jsonify(response), 200
 
@@ -1018,9 +1031,9 @@ async def update_conversation():
 
 @bp.route("/history/message_feedback", methods=["POST"])
 async def update_message():
+    await cosmos_db_ready.wait()
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
-    cosmos_conversation_client = init_cosmosdb_client()
 
     ## check request for message_id
     request_json = await request.get_json()
@@ -1034,7 +1047,7 @@ async def update_message():
             return jsonify({"error": "message_feedback is required"}), 400
 
         ## update the message in cosmos
-        updated_message = await cosmos_conversation_client.update_message_feedback(
+        updated_message = await current_app.cosmos_conversation_client.update_message_feedback(
             user_id, message_id, message_feedback
         )
         if updated_message:
@@ -1064,6 +1077,7 @@ async def update_message():
 
 @bp.route("/history/delete", methods=["DELETE"])
 async def delete_conversation():
+    await cosmos_db_ready.wait()
     ## get the user id from the request headers
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
@@ -1077,21 +1091,18 @@ async def delete_conversation():
             return jsonify({"error": "conversation_id is required"}), 400
 
         ## make sure cosmos is configured
-        cosmos_conversation_client = init_cosmosdb_client()
-        if not cosmos_conversation_client:
+        if not current_app.cosmos_conversation_client:
             raise Exception("CosmosDB is not configured or not working")
 
         ## delete the conversation messages from cosmos first
-        deleted_messages = await cosmos_conversation_client.delete_messages(
+        deleted_messages = await current_app.cosmos_conversation_client.delete_messages(
             conversation_id, user_id
         )
 
         ## Now delete the conversation
-        deleted_conversation = await cosmos_conversation_client.delete_conversation(
+        deleted_conversation = await current_app.cosmos_conversation_client.delete_conversation(
             user_id, conversation_id
         )
-
-        await cosmos_conversation_client.cosmosdb_client.close()
 
         return (
             jsonify(
@@ -1109,20 +1120,19 @@ async def delete_conversation():
 
 @bp.route("/history/list", methods=["GET"])
 async def list_conversations():
+    await cosmos_db_ready.wait()
     offset = request.args.get("offset", 0)
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
 
     ## make sure cosmos is configured
-    cosmos_conversation_client = init_cosmosdb_client()
-    if not cosmos_conversation_client:
+    if not current_app.cosmos_conversation_client:
         raise Exception("CosmosDB is not configured or not working")
 
     ## get the conversations from cosmos
-    conversations = await cosmos_conversation_client.get_conversations(
+    conversations = await current_app.cosmos_conversation_client.get_conversations(
         user_id, offset=offset, limit=25
     )
-    await cosmos_conversation_client.cosmosdb_client.close()
     if not isinstance(conversations, list):
         return jsonify({"error": f"No conversations for {user_id} were found"}), 404
 
@@ -1133,6 +1143,7 @@ async def list_conversations():
 
 @bp.route("/history/read", methods=["POST"])
 async def get_conversation():
+    await cosmos_db_ready.wait()
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
 
@@ -1144,12 +1155,11 @@ async def get_conversation():
         return jsonify({"error": "conversation_id is required"}), 400
 
     ## make sure cosmos is configured
-    cosmos_conversation_client = init_cosmosdb_client()
-    if not cosmos_conversation_client:
+    if not current_app.cosmos_conversation_client:
         raise Exception("CosmosDB is not configured or not working")
 
     ## get the conversation object and the related messages from cosmos
-    conversation = await cosmos_conversation_client.get_conversation(
+    conversation = await current_app.cosmos_conversation_client.get_conversation(
         user_id, conversation_id
     )
     ## return the conversation id and the messages in the bot frontend format
@@ -1164,7 +1174,7 @@ async def get_conversation():
         )
 
     # get the messages for the conversation from cosmos
-    conversation_messages = await cosmos_conversation_client.get_messages(
+    conversation_messages = await current_app.cosmos_conversation_client.get_messages(
         user_id, conversation_id
     )
 
@@ -1180,12 +1190,12 @@ async def get_conversation():
         for msg in conversation_messages
     ]
 
-    await cosmos_conversation_client.cosmosdb_client.close()
     return jsonify({"conversation_id": conversation_id, "messages": messages}), 200
 
 
 @bp.route("/history/rename", methods=["POST"])
 async def rename_conversation():
+    await cosmos_db_ready.wait()
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
 
@@ -1197,12 +1207,11 @@ async def rename_conversation():
         return jsonify({"error": "conversation_id is required"}), 400
 
     ## make sure cosmos is configured
-    cosmos_conversation_client = init_cosmosdb_client()
-    if not cosmos_conversation_client:
+    if not current_app.cosmos_conversation_client:
         raise Exception("CosmosDB is not configured or not working")
 
     ## get the conversation from cosmos
-    conversation = await cosmos_conversation_client.get_conversation(
+    conversation = await current_app.cosmos_conversation_client.get_conversation(
         user_id, conversation_id
     )
     if not conversation:
@@ -1220,16 +1229,16 @@ async def rename_conversation():
     if not title:
         return jsonify({"error": "title is required"}), 400
     conversation["title"] = title
-    updated_conversation = await cosmos_conversation_client.upsert_conversation(
+    updated_conversation = await current_app.cosmos_conversation_client.upsert_conversation(
         conversation
     )
 
-    await cosmos_conversation_client.cosmosdb_client.close()
     return jsonify(updated_conversation), 200
 
 
 @bp.route("/history/delete_all", methods=["DELETE"])
 async def delete_all_conversations():
+    await cosmos_db_ready.wait()
     ## get the user id from the request headers
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
@@ -1237,11 +1246,10 @@ async def delete_all_conversations():
     # get conversations for user
     try:
         ## make sure cosmos is configured
-        cosmos_conversation_client = init_cosmosdb_client()
-        if not cosmos_conversation_client:
+        if not current_app.cosmos_conversation_client:
             raise Exception("CosmosDB is not configured or not working")
 
-        conversations = await cosmos_conversation_client.get_conversations(
+        conversations = await current_app.cosmos_conversation_client.get_conversations(
             user_id, offset=0, limit=None
         )
         if not conversations:
@@ -1250,15 +1258,14 @@ async def delete_all_conversations():
         # delete each conversation
         for conversation in conversations:
             ## delete the conversation messages from cosmos first
-            deleted_messages = await cosmos_conversation_client.delete_messages(
+            deleted_messages = await current_app.cosmos_conversation_client.delete_messages(
                 conversation["id"], user_id
             )
 
             ## Now delete the conversation
-            deleted_conversation = await cosmos_conversation_client.delete_conversation(
+            deleted_conversation = await current_app.cosmos_conversation_client.delete_conversation(
                 user_id, conversation["id"]
             )
-        await cosmos_conversation_client.cosmosdb_client.close()
         return (
             jsonify(
                 {
@@ -1275,6 +1282,7 @@ async def delete_all_conversations():
 
 @bp.route("/history/clear", methods=["POST"])
 async def clear_messages():
+    await cosmos_db_ready.wait()
     ## get the user id from the request headers
     authenticated_user = get_authenticated_user_details(request_headers=request.headers)
     user_id = authenticated_user["user_principal_id"]
@@ -1288,12 +1296,11 @@ async def clear_messages():
             return jsonify({"error": "conversation_id is required"}), 400
 
         ## make sure cosmos is configured
-        cosmos_conversation_client = init_cosmosdb_client()
-        if not cosmos_conversation_client:
+        if not current_app.cosmos_conversation_client:
             raise Exception("CosmosDB is not configured or not working")
 
         ## delete the conversation messages from cosmos
-        deleted_messages = await cosmos_conversation_client.delete_messages(
+        deleted_messages = await current_app.cosmos_conversation_client.delete_messages(
             conversation_id, user_id
         )
 
@@ -1313,18 +1320,17 @@ async def clear_messages():
 
 @bp.route("/history/ensure", methods=["GET"])
 async def ensure_cosmos():
+    await cosmos_db_ready.wait()
     if not AZURE_COSMOSDB_ACCOUNT:
         return jsonify({"error": "CosmosDB is not configured"}), 404
 
     try:
-        cosmos_conversation_client = init_cosmosdb_client()
-        success, err = await cosmos_conversation_client.ensure()
-        if not cosmos_conversation_client or not success:
+        success, err = await current_app.cosmos_conversation_client.ensure()
+        if not current_app.cosmos_conversation_client or not success:
             if err:
                 return jsonify({"error": err}), 422
             return jsonify({"error": "CosmosDB is not configured or not working"}), 500
 
-        await cosmos_conversation_client.cosmosdb_client.close()
         return jsonify({"message": "CosmosDB is configured and working"}), 200
     except Exception as e:
         logging.exception("Exception in /history/ensure")
@@ -1364,7 +1370,7 @@ async def generate_title(conversation_messages):
     messages.append({"role": "user", "content": title_prompt})
 
     try:
-        azure_openai_client = init_openai_client(use_data=False)
+        azure_openai_client = await init_openai_client(use_data=False)
         response = await azure_openai_client.chat.completions.create(
             model=AZURE_OPENAI_MODEL, messages=messages, temperature=1, max_tokens=64
         )

--- a/app.py
+++ b/app.py
@@ -381,6 +381,7 @@ async def init_openai_client(use_data=SHOULD_USE_DATA):
 
 
 async def init_cosmosdb_client():
+    cosmos_conversation_client = None
     if CHAT_HISTORY_ENABLED:
         try:
             cosmos_endpoint = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ quart==0.19.4
 uvicorn==0.24.0
 aiohttp==3.9.2
 gunicorn==20.1.0
-asyncio==3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ quart==0.19.4
 uvicorn==0.24.0
 aiohttp==3.9.2
 gunicorn==20.1.0
+asyncio==3.4.3


### PR DESCRIPTION
### Motivation and Context

1. Why is this change required?

To resolve `Unclosed client session` errors which occur when the Web App service is running as well as when the local `start.sh` script is used to run the application. 

2. What problem does it solve?

As per issues #751 and #593 improper handling of database and other asynchronous connections results in `Unclosed client session` errors.

3. What scenario does it contribute to?

Using `.aio` libraries requires the proper handling and/or closing of asynchronous connections.

4. If it fixes an open issue, please link to the issue here.

It resolves issues #751 and #593.

5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.

It benefits all users who run the quart version of the app.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

As per the `CosmosClient` class in the `azure-cosmos` Python library, creating a database instance is a heavy operation:

> ... It's recommended to maintain a single instance of CosmosClient per lifetime of the application which enables efficient connection management and performance. CosmosClient initialization is a heavy operation, ...

To avoid multiple connection attempts, only a single global instance of the cosmos database connection is created in the `init()` function as part of the `create_app()` function. Only a single call to `init_cosmosdb_client()` is now needed instead of multiple calls within each function. This implementation leverages the `current_app` method of the `quart` library to maintain the database object's state during the lifetime of the application. When the database object is needed, it can be called using `current_app`, e.g., `current_app.cosmos_conversation_client.create_message(...)`

In addition, an `Event` is used to signal the readiness status of the database initialization to downstream functions to avoid the app calling methods of the `CosmosConversationClient` class before the client is completely initialized. Without this approach, a user would see an error on the frontend that disappears only once the initialization is complete. Functions can 'wait' on the database using the `.wait()` method of the `Event` class.

Another source of the `Unclosed client session` error stems from the use of the asynchronous import of `DefaultAzureCredential` from `.aio`. This connection is handled using a context created by the `async with` statement. Thanks to [QuentinAd](https://github.com/microsoft/sample-app-aoai-chatGPT/issues/751#issuecomment-2066296718) for the template.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ x ] I have built and tested the code locally and in a deployed app
- [ x ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ x ] I didn't break any existing functionality :smile: 🤞 
