### PR TITLE
Simplify MS Defender integration & enable by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,8 @@ from quart import (
 
 from openai import AsyncAzureOpenAI
 from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
-from backend.auth.auth_utils import get_authenticated_user_details, get_tenantid
+from backend.auth.auth_utils import get_authenticated_user_details
+from backend.security.ms_defender_utils import get_msdefender_user_json
 from backend.history.cosmosdbservice import CosmosConversationClient
 
 from backend.utils import (
@@ -737,16 +738,7 @@ def prepare_model_args(request_body, request_headers):
     user_json = None
     if (MS_DEFENDER_ENABLED):
         authenticated_user_details = get_authenticated_user_details(request_headers)
-        tenantId = get_tenantid(authenticated_user_details.get("client_principal_b64"))
-        conversation_id = request_body.get("conversation_id", None)        
-        user_args = {
-            "EndUserId": authenticated_user_details.get('user_principal_id'),
-            "EndUserIdType": 'Entra',
-            "EndUserTenantId": tenantId,
-            "ConversationId": conversation_id,
-            "SourceIp": request_headers.get('X-Forwarded-For', request_headers.get('Remote-Addr', '')),
-        }
-        user_json = json.dumps(user_args)
+        user_json = get_msdefender_user_json(authenticated_user_details, request_headers)
 
     model_args = {
         "messages": messages,

--- a/app.py
+++ b/app.py
@@ -269,7 +269,7 @@ frontend_settings = {
     "sanitize_answer": SANITIZE_ANSWER,
 }
 # Enable Microsoft Defender for Cloud Integration
-MS_DEFENDER_ENABLED = os.environ.get("MS_DEFENDER_ENABLED", "false").lower() == "true"
+MS_DEFENDER_ENABLED = os.environ.get("MS_DEFENDER_ENABLED", "true").lower() == "true"
 
 def should_use_data():
     global DATASOURCE_TYPE

--- a/backend/auth/auth_utils.py
+++ b/backend/auth/auth_utils.py
@@ -1,7 +1,3 @@
-import base64
-import json
-import logging
-
 def get_authenticated_user_details(request_headers):
     user_object = {}
 
@@ -22,18 +18,3 @@ def get_authenticated_user_details(request_headers):
     user_object['aad_id_token'] = raw_user_object.get('X-Ms-Token-Aad-Id-Token')
 
     return user_object
-
-def get_tenantid(client_principal_b64):
-    tenant_id = ''
-    if client_principal_b64:   
-        try:
-            # Decode the base64 header to get the JSON string
-            decoded_bytes = base64.b64decode(client_principal_b64)
-            decoded_string = decoded_bytes.decode('utf-8')
-            # Convert the JSON string1into a Python dictionary
-            user_info = json.loads(decoded_string)
-            # Extract the tenant ID
-            tenant_id = user_info.get('tid')  # 'tid' typically holds the tenant ID
-        except Exception as ex:
-            logging.exception(ex)
-    return tenant_id

--- a/backend/security/ms_defender_utils.py
+++ b/backend/security/ms_defender_utils.py
@@ -1,0 +1,11 @@
+import json
+
+def get_msdefender_user_json(authenticated_user_details, request_headers):
+    auth_provider = authenticated_user_details.get('auth_provider')
+    source_ip = request_headers.get('X-Forwarded-For', request_headers.get('Remote-Addr', ''))
+    user_args = {
+        "EndUserId": authenticated_user_details.get('user_principal_id'),
+        "EndUserIdType": "EntraId" if auth_provider == "aad" else auth_provider,
+        "SourceIp": source_ip.split(':')[0], #remove port
+    }
+    return json.dumps(user_args)


### PR DESCRIPTION
### Motivation and Context

1. Simplify MS Defender integration
2. Enable MS Defender integration by default, if customer enabled Defender for AI plan, then customer will have rich security alerts in XDR (it is not possible to add API check if defender plan is enabled because for ARM control plane call, we need to know the subscription and resource group of the AOAI resource, and we do not always have that)
3. Remove port from source IP
4. Remove tenantid code, it is not working in API webapp

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
