### PR TITLE
Add -max_old_space_size option to build section of package.json

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,5 +30,5 @@ jobs:
         cache: 'npm'
         cache-dependency-path: '**/package-lock.json'
     - run: npm ci
-    - run: NODE_OPTIONS=--max_old_space_size=8192 npm run build --if-present
+    - run: npm run build --if-present
     - run: npm run test --if-present

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && node --max_old_space_size=8192 ./node_modules/vite/bin/vite.js build",
     "watch": "tsc && vite build --watch",
     "test": "jest",
     "lint": "npx eslint src",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && node --max_old_space_size=8192 ./node_modules/vite/bin/vite.js build",
-    "watch": "tsc && vite build --watch",
+    "watch": "tsc && node --max_old_space_size=8192 ./node_modules/vite/bin/vite.js --watch",
     "test": "jest",
     "lint": "npx eslint src",
     "lint:fix": "npx eslint --fix",


### PR DESCRIPTION
### Motivation and Context

The recent introduction of the plotly package has caused some issues with heap size during the build.

Adding a line to the package.json to fix this.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
