### PR TITLE
Remove docker login step from the build workflow

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -12,16 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Azure Container Registry Login
-      uses: Azure/docker-login@v2
-      with:
-        # Container registry username
-        username: ${{ secrets.SAMPLEAPP_ACR_USERNAME }}
-        # Container registry password
-        password: ${{ secrets.SAMPLEAPP_ACR_PASSWORD }}
-        # Container registry server url
-        login-server: sampleappaoaichatgpt.azurecr.io
-        
     - uses: actions/checkout@v3
     - name: Build the Docker image
       run:         

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Azure Container Registry Login
-      uses: Azure/docker-login@v1
+      uses: Azure/docker-login@v2
       with:
         # Container registry username
         username: ${{ secrets.SAMPLEAPP_ACR_USERNAME }}

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -12,19 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-<<<<<<< HEAD
-=======
-    - name: Azure Container Registry Login
-      uses: Azure/docker-login@v2
-      with:
-        # Container registry username
-        username: ${{ secrets.SAMPLEAPP_ACR_USERNAME }}
-        # Container registry password
-        password: ${{ secrets.SAMPLEAPP_ACR_PASSWORD }}
-        # Container registry server url
-        login-server: sampleappaoaichatgpt.azurecr.io
-        
->>>>>>> bd16c6488eba124cb4536eac7b4b85faf17f043a
     - uses: actions/checkout@v3
     - name: Build the Docker image
       run:         

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Azure Container Registry Login
-      uses: Azure/docker-login@v1
+      uses: Azure/docker-login@v2
       with:
         # Container registry username
         username: ${{ secrets.SAMPLEAPP_ACR_USERNAME }}


### PR DESCRIPTION
### Description

Docker login won't pull secrets from PRs created from forks, which is causing failure during the PR gate for testing that the docker image builds successfully.

We don't push anything in this workflow, so we should be able to remove the login step from it without causing issues to fix this.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
