### PR TITLE
fix: make frontend build and app deploy

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -12,12 +12,20 @@ services:
       prepackage:
         windows:
           shell: pwsh
-          run:  cd ./frontend;npm install;npm run build
+          run: |
+            cd ./frontend
+            npm install
+            $env:NODE_OPTIONS="--max_old_space_size=8192"
+            npm run build
           interactive: true
           continueOnError: false
         posix:
           shell: sh
-          run:  cd ./frontend;npm install;npm run build
+          run: |
+            cd ./frontend
+            npm install
+            export NODE_OPTIONS=--max_old_space_size=8192
+            npm run build
           interactive: true
           continueOnError: false
 hooks:
@@ -35,11 +43,17 @@ hooks:
     postprovision:
       windows:
         shell: pwsh
-        run: ./scripts/auth_update.ps1;./scripts/prepdocs.ps1;
+        run: |
+          $env:FLAG_AOAI="V2"
+          ./scripts/auth_update.ps1
+          ./scripts/prepdocs.ps1
         interactive: true
         continueOnError: false
       posix:
         shell: sh
-        run: ./scripts/auth_update.sh;./scripts/prepdocs.sh;
+        run: |
+          export FLAG_AOAI="V2"
+          ./scripts/auth_update.sh
+          ./scripts/prepdocs.sh
         interactive: true
         continueOnError: false

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -110,6 +110,7 @@ module backend 'core/host/appservice.bicep' = {
     runtimeVersion: '3.10'
     scmDoBuildDuringDeployment: true
     managedIdentity: true
+    appCommandLine: 'python3 -m gunicorn app:app'
     authClientSecret: authClientSecret
     authClientId: authClientId
     authIssuerUri: authIssuerUri
@@ -137,6 +138,7 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_OPENAI_STOP_SEQUENCE: openAIStopSequence
       AZURE_OPENAI_SYSTEM_MESSAGE: openAISystemMessage
       AZURE_OPENAI_STREAM: openAIStream
+      DATASOURCE_TYPE: 'AzureCognitiveSearch'
     }
   }
 }

--- a/scripts/prepdocs.sh
+++ b/scripts/prepdocs.sh
@@ -3,4 +3,4 @@
 . ./scripts/loadenv.sh
 
 echo 'Running "prepdocs.py"'
-./.venv/bin/python ./scripts/prepdocs.py --searchservice "$AZURE_SEARCH_SERVICE" --index "$AZURE_SEARCH_INDEX" --formrecognizerservice "$AZURE_FORMRECOGNIZER_SERVICE" --tenantid "$AZURE_TENANT_ID" --embeddingendpoint "$AZURE_OPENAI_EMBEDDING_ENDPOINT"
+./.venv/bin/python ./scripts/prepdocs.py --searchservice "$AZURE_SEARCH_SERVICE" --index "$AZURE_SEARCH_INDEX" --formrecognizerservice "$AZURE_FORMRECOGNIZER_SERVICE" --tenantid "$AZURE_TENANT_ID" --embeddingendpoint "https://$AZURE_OPENAI_RESOURCE.openai.azure.com/openai/deployments/$AZURE_OPENAI_EMBEDDING_NAME/embeddings?api-version=2024-06-01"


### PR DESCRIPTION
### Motivation and Context

Fix the deployment issues when using the AZD command. 

### Description

This PR addresses the following issues:

- **Build Failures**: The deployment through AZD fails due to out-of-memory (OOM).
- **Post-Provision Hooks**: The post-provision hooks fail because the embedding endpoint is incorrectly configured.
- **App Service Startup**: The app service doesn't start due to a missing startup command.
- **Incorrect Configuration**: The app is incorrectly configured and doesn't perform Retrieval-Augmented Generation (RAG) because `DATASOURCE_TYPE` is not set.

### Contribution Checklist

- [x] I have built and tested the code locally and in a deployed app. _(only posix)_