### PR TITLE
Fix error in first question when using PF

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -175,10 +175,10 @@ def format_pf_non_streaming_response(
             "model": "",
             "created": "",
             "object": "",
+            "history_metadata": history_metadata,
             "choices": [
                 {
                     "messages": messages,
-                    "history_metadata": history_metadata,
                 }
             ]
         }


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  **To unblock customer**
  2. What problem does it solve?
  **First question in conversation gets default error**
  3. What scenario does it contribute to?
  **Prompt Flow with Chat History enabled**
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

*history_metadata* was inside *choices* object when formatting non streaming response from Prompt Flow endpoint

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [X] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [X] I didn't break any existing functionality :smile:
