### PR TITLE
Minor improvements to build process and startup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The interface allows for easy adaptation of the UI by modifying certain elements
 - `UI_SHOW_SHARE_BUTTON`
 - `UI_SHOW_CHAT_HISTORY_BUTTON`
 
+Any custom images assigned to variables `UI_LOGO`, `UI_CHAT_LOGO` or `UI_FAVICON` should be added to the [public](https://github.com/microsoft/sample-app-aoai-chatGPT/tree/main/frontend/public) folder before building the project.  The Vite build process will automatically copy theses files to the [static](https://github.com/microsoft/sample-app-aoai-chatGPT/tree/main/static) folder on each build of the frontend.  The corresponding environment variables should then be set using a relative path such as `static/<my image filename>` to ensure that the frontend code can find them.
+
 Feel free to fork this repository and make your own modifications to the UX or backend logic. You can modify the source (`frontend/src`). For example, you may want to change aspects of the chat display, or expose some of the settings in `app.py` in the UI for users to try out different behaviors. After your code changes, you will need to rebuild the front-end via `start.sh` or `start.cmd`.
 
 ### Scalability

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: '../static',
-    emptyOutDir: true,
+    emptyOutDir: false,
     sourcemap: true
   },
   server: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: '../static',
-    emptyOutDir: false,
+    emptyOutDir: true,
     sourcemap: true
   },
   server: {

--- a/start.cmd
+++ b/start.cmd
@@ -1,5 +1,18 @@
 @echo off
+setlocal
+REM Sample app startup script
 
+REM Process CLI options
+set CMD=%~1
+if "%CMD%" == "" (
+    echo Building the application.  To skip this step in the future, use the `--skip-build` option.
+    goto build
+) else if "%CMD%" == "--skip-build" (
+    echo Skipping build...
+    goto run
+)
+
+:build
 set NODE_OPTIONS=--max_old_space_size=8192
 
 echo.
@@ -30,6 +43,7 @@ if "%errorlevel%" neq "0" (
     exit /B %errorlevel%
 )
 
+:run
 echo.    
 echo Starting backend    
 echo.    

--- a/start.sh
+++ b/start.sh
@@ -1,34 +1,76 @@
-#!/bin/bash
+#!/bin/bash -e
+
+# script usage info
+function usage() {
+    cat <<USAGE
+
+    Usage: $0 [-s|--skip-build]
+
+    Options:
+        -s, --skip-build:              Optional.
+USAGE
+    exit 1
+}
+
+function build() {
+    echo "Building the application.  To skip this step in the future, use the `--skip-build` option."
+    echo ""
+    echo "Restoring frontend npm packages"
+    echo ""
+    cd frontend
+    npm install
+    if [ $? -ne 0 ]; then
+        echo "Failed to restore frontend npm packages"
+        exit $?
+    fi
+
+    echo ""
+    echo "Building frontend"
+    echo ""
+    npm run build
+    if [ $? -ne 0 ]; then
+        echo "Failed to build frontend"
+        exit $?
+    fi
+    cd ..
+
+    echo ""
+    echo "Restoring backend python packages"
+    . ./scripts/loadenv.sh
+}
+
+function run() {
+    echo ""
+    echo "Starting backend"
+    echo ""
+    ./.venv/bin/python -m quart run --port=50505 --host=127.0.0.1 --reload
+    if [ $? -ne 0 ]; then
+        echo "Failed to start backend"
+        exit $?
+    fi
+}
+
+SKIP_BUILD=0
+while [ "$1" != "" ]; do
+    case $1 in
+    -s | --skip-build)
+        SKIP_BUILD=1
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+    shift
+done
 
 export NODE_OPTIONS=--max_old_space_size=8192
 
-echo ""
-echo "Restoring frontend npm packages"
-echo ""
-cd frontend
-npm install
-if [ $? -ne 0 ]; then
-    echo "Failed to restore frontend npm packages"
-    exit $?
+if [[ $SKIP_BUILD == 0 ]]; then
+    build
 fi
 
-echo ""
-echo "Building frontend"
-echo ""
-npm run build
-if [ $? -ne 0 ]; then
-    echo "Failed to build frontend"
-    exit $?
-fi
+run
 
-cd ..
-. ./scripts/loadenv.sh
 
-echo ""
-echo "Starting backend"
-echo ""
-./.venv/bin/python -m quart run --port=50505 --host=127.0.0.1 --reload
-if [ $? -ne 0 ]; then
-    echo "Failed to start backend"
-    exit $?
-fi
+


### PR DESCRIPTION
### Motivation and Context

This PR makes 2 main changes:
1) Change vite build options to not overwrite the `static` directory on build, which can cause custom images to be removed from this folder if they have been added.
2) Create an option to skip the build in the startup scripts to save time if only making config or backend changes.  The option is additive, so current users of these scripts will not notice the change unless the new option `--skip-build` is provided on the command line.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [X] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [X] I didn't break any existing functionality :smile:
