### PR TITLE
Prevent ingestion failure on empty tables

### DIFF
--- a/scripts/data_utils.py
+++ b/scripts/data_utils.py
@@ -616,10 +616,12 @@ def extract_pdf_content(file_path, form_recognizer_client, use_layout=False):
         if use_layout:
             tables_on_page = []
             for table in form_recognizer_results.tables:
-                table_offset = table.spans[0].offset
-                table_length = table.spans[0].length
-                if page_offset <= table_offset and table_offset + table_length < page_offset + page_length:
-                    tables_on_page.append(table)
+                # If the table is empty, the span is empty, so we skip it
+                if len(table.spans) > 0:
+                    table_offset = table.spans[0].offset
+                    table_length = table.spans[0].length
+                    if page_offset <= table_offset and table_offset + table_length < page_offset + page_length:
+                        tables_on_page.append(table)
         else:
             tables_on_page = []
 


### PR DESCRIPTION
### Motivation and Context

This address the bug mentioned in #1034 where the data preparation script fails when the table is empty.

### Description

All this PR does is add a check to make sure there is a "span" of the text that each table corresponds to. If there is no such span, then it skips the table since that means it's just an empty table with no information.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files. (N/A)
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
