### PR TITLE
Fixes deployment location of cosmosdb

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -200,7 +200,7 @@ module cosmos 'db.bicep' = {
   scope: resourceGroup
   params: {
     accountName: !empty(cosmosAccountName) ? cosmosAccountName : '${abbrs.documentDBDatabaseAccounts}${resourceToken}'
-    location: 'eastus'
+    location: resourceGroup.location
     tags: tags
     principalIds: [principalId, backend.outputs.identityPrincipalId]
   }


### PR DESCRIPTION
### Motivation and Context

The deployment location was hard coded to `eastus`.

### Description

 This change changes this to use the value of `resourceGroup.location` instead.