### PR TITLE
Grant ownership to the package JSON file for installation step

### DIFF
--- a/WebApp.Dockerfile
+++ b/WebApp.Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine AS frontend
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 
 WORKDIR /home/node/app 
-COPY ./frontend/package*.json ./  
+COPY --chown=node:node ./frontend/package*.json ./  
 USER node
 RUN npm ci  
 COPY --chown=node:node ./frontend/ ./frontend  

--- a/WebApp.Dockerfile
+++ b/WebApp.Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /home/node/app
 COPY --chown=node:node ./frontend/package*.json ./  
 USER node
 RUN npm ci  
-COPY --chown=node:node ./frontend/ ./frontend  
-COPY --chown=node:node ./static/ ./static  
+COPY ./frontend/ ./frontend  
+COPY ./static/ ./static  
 WORKDIR /home/node/app/frontend
 RUN NODE_OPTIONS=--max_old_space_size=8192 npm run build
   


### PR DESCRIPTION
### Motivation and Context

The change is required for local development when building docker images for testing purposes.

It fixes the  #1083 issue.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
The `npm ci` is not able to run if it has no ownership over the `package.json` files. Similar to other `COPY` phase, the `--chown=node:node` option was added.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
