### PR TITLE
Fix Citation Format for Prompt Flow Endpoint Responses

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -166,10 +166,12 @@ def format_pf_non_streaming_response(
                 "content": chatCompletion[response_field_name] 
             })
         if citations_field_name in chatCompletion:
+            citation_content= {"citations": chatCompletion[citations_field_name]}
             messages.append({ 
                 "role": "tool",
-                "content": chatCompletion[citations_field_name]
+                "content": json.dumps(citation_content)
             })
+
         response_obj = {
             "id": chatCompletion["id"],
             "model": "",


### PR DESCRIPTION
Modify the format for citations field in the promptflow response post processing stage, so that citation shows up in UI.Fixing issue reported: https://portal.microsofticm.com/imp/v5/incidents/details/540126530/summary

### Motivation and Context

1. Why is this change required? 
    Currently, when users point webapp to a promptflow endpoint instead of OYD, they are unable to see citations in the frontend and interact with them.
  2. What problem does it solve?
  Now citations show up and user can click and interact with them in Web App UI
  3. What scenario does it contribute to?
  Prompt flow endpoint integration
  4. If it fixes an open issue, please link to the issue here.
  Issue: https://portal.microsofticm.com/imp/v5/incidents/details/540126530/summary
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
  All users who want to integrate with prompt flow endpoints that return citations,

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

[X] I have built and tested the code locally and in a deployed app
[X] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
[X] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
[X] I didn't break any existing functionality :smile:
