### PR TITLE
Set auth_emabled to true by default

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -753,7 +753,7 @@ class _BaseSettings(BaseSettings):
         env_ignore_empty=True
     )
     datasource_type: Optional[str] = None
-    auth_enabled: bool = False
+    auth_enabled: bool = True
     sanitize_answer: bool = False
     use_promptflow: bool = False
 


### PR DESCRIPTION
### Motivation and Context

The default value for auth_enabled should be true.

### Description


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
