### PR TITLE
gather chunks before uploading docs to index for correct ID count

### DIFF
--- a/scripts/data_preparation.py
+++ b/scripts/data_preparation.py
@@ -404,6 +404,7 @@ def create_index(config, credential, form_recognizer_client=None, embedding_mode
     if "data_paths" in config:
         data_configs.extend(config["data_paths"])
 
+    result_chunks = [];
     for data_config in data_configs:
         # chunk directory
         print(f"Chunking path {data_config['path']}...")
@@ -431,9 +432,12 @@ def create_index(config, credential, form_recognizer_client=None, embedding_mode
         print(f"Files with errors: {result.num_files_with_errors} files")
         print(f"Found {len(result.chunks)} chunks")
 
-        # upload documents to index
-        print("Uploading documents to index...")
-        upload_documents_to_index(service_name, subscription_id, resource_group, index_name, result.chunks, credential)
+        # combine all chunks from different data paths together for upload
+        result_chunks.extend(result.chunks)
+
+    # upload documents to index
+    print("Uploading documents to index...")
+    upload_documents_to_index(service_name, subscription_id, resource_group, index_name, result_chunks, credential)
 
     # check if index is ready/validate index
     print("Validating index...")


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? if there are multiple data paths, the ID of the chunks uploaded will be duplicated and resulting in data missing
  2. What problem does it solve? Gather the chunks from all data paths then upload will prevent duplicated ID
  3. What scenario does it contribute to? when there are multiple data paths
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app. Yes
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

When there are multiple data paths (`data_path`) specified in the config.json, the `upload_documents_to_index` function originally executes during each data path, where the ID starts from 0. Therefore, there will always be duplicated IDs between the follow up chunks from the other data paths. This issue was found where some data went missing from the search index created.

Here's an easy way to fix it. Don't upload until all chunks are ready and gathered into one array.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [ ] ~For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.~ does not apply
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
