### PR TITLE
Update initializeIcons function call to load from new CDN location (Fixes #1249)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@fluentui/react": "^8.105.3",
+        "@fluentui/react": "^8.109.0",
         "@fluentui/react-hooks": "^8.6.29",
         "@fluentui/react-icons": "^2.0.195",
         "dompurify": "^3.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@fluentui/react": "^8.105.3",
+    "@fluentui/react": "^8.109.0",
     "@fluentui/react-hooks": "^8.6.29",
     "@fluentui/react-icons": "^2.0.195",
     "dompurify": "^3.0.8",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,7 +10,7 @@ import { AppStateProvider } from './state/AppProvider'
 
 import './index.css'
 
-initializeIcons()
+initializeIcons("https://res.cdn.office.net/files/fabric-cdn-prod_20241209.001/assets/icons/")
 
 export default function App() {
   return (


### PR DESCRIPTION
Default CDN being loaded by the initializeIcons method was decommissioned on January 15, 2025. See https://github.com/microsoft/fluentui/issues/33612

### Motivation and Context
Fixes #1249 - Empty Icons

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Updates call to initializeIcons() in index.tsx to reference a specific CDN location.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] I have built and tested the code locally and in a deployed app
- [X] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [X] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [X] I didn't break any existing functionality :smile:
