### PR TITLE
fix pydantic warnings

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -161,11 +161,11 @@ class _AzureOpenAISettings(BaseSettings):
     @model_validator(mode="after")
     def ensure_endpoint(self) -> Self:
         if self.endpoint:
-            return Self
+            return self
         
         elif self.resource:
             self.endpoint = f"https://{self.resource}.openai.azure.com"
-            return Self
+            return self
         
         raise ValidationError("AZURE_OPENAI_ENDPOINT or AZURE_OPENAI_RESOURCE is required")
         
@@ -314,6 +314,7 @@ class _AzureSearchSettings(BaseSettings, DatasourcePayloadConstructor):
     @model_validator(mode="after")
     def set_query_type(self) -> Self:
         self.query_type = to_snake(self.query_type)
+        return self
 
     def _set_filter_string(self, request: Request) -> str:
         if self.permitted_groups_column:


### PR DESCRIPTION
Fixed two typos that would trigger "validator not returning self"-warning from pydantic. Also returning self where previously returning None, to be consistent.

### Motivation and Context

Starting the backend can trigger "not returning self"-warning. See https://docs.pydantic.dev/2.9/concepts/validators/#model-validators

Even though pydantic dev-version does not trigger this warning anymore, the changes are removing typos and ensuring consistency.

### Description

Changed two typos from "return Self" to "return self".  Also added "return self" for one validator to be consistent.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ X ] I have built and tested the code locally and in a deployed app
- [ X ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ X ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ X ] I didn't break any existing functionality :smile:
