### PR TITLE
updated stop generating button's cursor from text to pointer

### DIFF
--- a/frontend/src/pages/chat/Chat.module.css
+++ b/frontend/src/pages/chat/Chat.module.css
@@ -213,6 +213,7 @@
   bottom: 116px;
   border: 1px solid #d1d1d1;
   border-radius: 16px;
+  cursor: pointer;
 }
 
 .stopGeneratingIcon {


### PR DESCRIPTION
Fixes #1323 
### Motivation and Context
Currently, when hovering over the **Stop generating** button, the cursor appears as a text cursor (cursor: text) instead of a pointer (cursor: pointer). Since the button is clickable, this behavior is misleading and may suggest that the button is meant for text input rather than an interactive action.

Issue Snapshot-
![Image](https://github.com/user-attachments/assets/4f24a7b5-46e7-4324-a3f1-06289a72643d)

<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
I have updated the button's CSS to explicitly set cursor: pointer. This change contributes to better user experience across the UI.

After My Changes Snapshot-
![image](https://github.com/user-attachments/assets/0a7960fc-5525-4344-bc45-de0987442fab)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [x] I didn't break any existing functionality :smile:
